### PR TITLE
Add Apple-inspired hotel landing page example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Demo_websiteRealEstate
- RealEstate website test
+
+RealEstate website test
+
+## Hotel landing page demo
+
+De file `hotel.html` bevat een eenvoudige, moderne landing page geïnspireerd op het design van Apple.

--- a/hotel.css
+++ b/hotel.css
@@ -1,0 +1,70 @@
+:root {
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --text-color: #111;
+    --accent: #0071e3;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--text-color);
+    background: #fff;
+}
+
+.hero {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    background: url('appartement1.jpg') center/cover no-repeat;
+    color: #fff;
+    padding: 0 1rem;
+}
+
+.hero h1 {
+    font-size: 3rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.hero p {
+    font-size: 1.2rem;
+    margin-top: 1rem;
+}
+
+.cta {
+    margin-top: 2rem;
+    padding: 0.75rem 1.5rem;
+    background: var(--accent);
+    color: #fff;
+    border-radius: 30px;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.features {
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+    padding: 4rem 1rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.feature {
+    text-align: center;
+}
+
+.feature h2 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+footer {
+    text-align: center;
+    padding: 2rem;
+    background: #f5f5f7;
+    font-size: 0.9rem;
+}

--- a/hotel.html
+++ b/hotel.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Museum Hotel</title>
+    <link rel="stylesheet" href="hotel.css">
+</head>
+<body>
+    <header class="hero">
+        <h1>Museum Hotel</h1>
+        <p>Stijlvol verblijven in het hart van de stad</p>
+        <a class="cta" href="#book">Boek nu</a>
+    </header>
+
+    <section class="features">
+        <div class="feature">
+            <h2>Design kamers</h2>
+            <p>Minimalistische kamers met alle moderne gemakken.</p>
+        </div>
+        <div class="feature">
+            <h2>Perfecte locatie</h2>
+            <p>Op loopafstand van musea, winkels en restaurants.</p>
+        </div>
+        <div class="feature">
+            <h2>Service 24/7</h2>
+            <p>Ons team staat dag en nacht voor u klaar.</p>
+        </div>
+    </section>
+
+    <footer>
+        <p>&copy; 2024 Museum Hotel</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimalistic hotel landing page prototype (`hotel.html` and `hotel.css`)
- document demo landing page in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6b016ae0832a857bdb859e54e78c