### PR TITLE
Add proactive assistant mock with safer tool flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Sender, Message, ToolCallData, AnalysisState, GeminiToolCall } from './types';
+import InputArea from './components/InputArea';
+import ChatMessage from './components/ChatMessage';
+import { initializeChat, sendMessageToGemini, sendToolResponseToGemini } from './services/geminiService';
+
+interface ToolDefinition {
+  name: string;
+  description: string;
+  autoExecute: boolean;
+  handler: (args: Record<string, unknown>) => string;
+}
+
+const TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    name: 'list_calendar_events',
+    description: 'Overzicht van komende afspraken in Google Agenda',
+    autoExecute: true,
+    handler: () =>
+      JSON.stringify([
+        {
+          summary: 'Lunch met Jan',
+          start: { dateTime: new Date(Date.now() + 86400000).toISOString() },
+          description: 'Bespreking project X'
+        },
+        {
+          summary: 'Tandartscontrole',
+          start: { dateTime: new Date(Date.now() + 172800000).toISOString() }
+        }
+      ])
+  },
+  {
+    name: 'read_gmail_inbox',
+    description: 'Recente e-mails ophalen uit Gmail',
+    autoExecute: true,
+    handler: () =>
+      JSON.stringify([
+        {
+          from: 'jan@bedrijf.nl',
+          subject: 'Project update',
+          snippet: 'Het gaat goed met de voortgang, kunnen we morgen even bellen?'
+        },
+        {
+          from: 'nieuwsbrief@tech.com',
+          subject: 'Wekelijkse update',
+          snippet: 'De nieuwe AI trends van deze week...'
+        }
+      ])
+  },
+  {
+    name: 'list_tasks',
+    description: 'Takenlijst uit Google Tasks',
+    autoExecute: true,
+    handler: () =>
+      JSON.stringify([
+        { title: 'Rapport afmaken', status: 'needsAction' },
+        { title: 'Bloemen bestellen', status: 'completed' }
+      ])
+  },
+  {
+    name: 'search_web',
+    description: 'Snelle webzoekopdracht uitvoeren',
+    autoExecute: true,
+    handler: (args) => `Webzoekopdracht uitgevoerd voor ${JSON.stringify(args)}`
+  },
+  {
+    name: 'draft_email',
+    description: 'Concept e-mail voorbereiden in Gmail (met bevestiging)',
+    autoExecute: false,
+    handler: (args) => `Concept-e-mail voorbereid: ${JSON.stringify(args)}`
+  }
+];
+
+const findToolDefinition = (name: string): ToolDefinition | undefined =>
+  TOOL_DEFINITIONS.find((tool) => tool.name === name);
+
+const createId = () => (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`);
+
+const App: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [analysisState, setAnalysisState] = useState<AnalysisState>({ isAnalyzing: false, statusMessage: '' });
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    initializeChat();
+    setMessages([
+      {
+        id: createId(),
+        sender: Sender.ASSISTANT,
+        text:
+          'Hallo! Ik ben je proactieve assistent. Ik kan je Google Workspace-apps lezen en schrijven, maar voer acties pas uit na jouw akkoord. Waarmee kan ik helpen?',
+        timestamp: Date.now()
+      }
+    ]);
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, analysisState.isAnalyzing]);
+
+  const performToolExecution = (name: string, args: Record<string, unknown>): string => {
+    const toolDefinition = findToolDefinition(name);
+    if (!toolDefinition) {
+      throw new Error(`Onbekende tool: ${name}`);
+    }
+    return toolDefinition.handler(args);
+  };
+
+  const showErrorMessage = (text: string) => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: createId(),
+        sender: Sender.SYSTEM,
+        text,
+        timestamp: Date.now()
+      }
+    ]);
+  };
+
+  const appendSystemNote = (note: string) => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: createId(),
+        sender: Sender.SYSTEM,
+        text: 'Automatische gegevensverzameling uitgevoerd.',
+        systemNote: note,
+        timestamp: Date.now()
+      }
+    ]);
+  };
+
+  const enrichToolCalls = (toolCalls?: GeminiToolCall[]): ToolCallData[] | undefined =>
+    toolCalls?.map((call) => {
+      const definition = findToolDefinition(call.name);
+      return {
+        id: call.id,
+        name: call.name,
+        args: call.args,
+        status: 'pending',
+        userConfirmationRequired: !definition?.autoExecute
+      };
+    });
+
+  const handleSendMessage = async (text: string, image: string | null) => {
+    const userMsg: Message = {
+      id: createId(),
+      sender: Sender.USER,
+      text: text || undefined,
+      image: image || undefined,
+      timestamp: Date.now()
+    };
+
+    setMessages((prev) => [...prev, userMsg]);
+    setAnalysisState({ isAnalyzing: true, statusMessage: 'Situatie analyseren...' });
+
+    try {
+      const response = await sendMessageToGemini(text, image || undefined);
+      let assistantText = response.textResponse;
+      let pendingToolCalls = enrichToolCalls(response.toolCalls);
+
+      const autoTools = pendingToolCalls?.filter((t) => findToolDefinition(t.name)?.autoExecute);
+      const manualTools = pendingToolCalls?.filter((t) => !findToolDefinition(t.name)?.autoExecute);
+
+      if (autoTools && autoTools.length > 0) {
+        setAnalysisState({ isAnalyzing: true, statusMessage: 'Gegevens ophalen...' });
+        const executedResults = autoTools.map((t) => ({
+          ...t,
+          result: performToolExecution(t.name, t.args),
+          status: 'executed' as const
+        }));
+
+        appendSystemNote(
+          `Automatisch uitgevoerd: ${executedResults
+            .map((t) => `${t.name} (${findToolDefinition(t.name)?.description || 'nvt'})`)
+            .join(', ')}.`
+        );
+
+        const followUpText = await sendToolResponseToGemini(executedResults);
+        assistantText = followUpText;
+        pendingToolCalls = manualTools && manualTools.length > 0 ? manualTools : undefined;
+      }
+
+      const assistantMsg: Message = {
+        id: createId(),
+        sender: Sender.ASSISTANT,
+        text: assistantText,
+        toolCalls: pendingToolCalls,
+        timestamp: Date.now()
+      };
+
+      setMessages((prev) => [...prev, assistantMsg]);
+    } catch (error) {
+      console.error(error);
+      showErrorMessage('Er ging iets mis bij het verbinden met de assistent. Probeer het opnieuw.');
+    } finally {
+      setAnalysisState({ isAnalyzing: false, statusMessage: '' });
+    }
+  };
+
+  const executeAction = async (toolCall: ToolCallData, messageId: string) => {
+    try {
+      const executionResult = performToolExecution(toolCall.name, toolCall.args);
+      setMessages((prev) =>
+        prev.map((msg) => {
+          if (msg.id === messageId && msg.toolCalls) {
+            return {
+              ...msg,
+              toolCalls: msg.toolCalls.map((tc) =>
+                tc.id === toolCall.id ? { ...tc, status: 'executed', result: executionResult } : tc
+              )
+            };
+          }
+          return msg;
+        })
+      );
+
+      setAnalysisState({ isAnalyzing: true, statusMessage: 'Actie bevestigen aan assistent...' });
+      const textResponse = await sendToolResponseToGemini([{ ...toolCall, result: executionResult }]);
+
+      if (textResponse) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: createId(),
+            sender: Sender.ASSISTANT,
+            text: textResponse,
+            timestamp: Date.now()
+          }
+        ]);
+      }
+    } catch (error) {
+      console.error('Failed to execute tool', error);
+      showErrorMessage('Uitvoeren van de actie is mislukt. Controleer de parameters en probeer opnieuw.');
+    } finally {
+      setAnalysisState({ isAnalyzing: false, statusMessage: '' });
+    }
+  };
+
+  const rejectAction = (toolCall: ToolCallData, messageId: string) => {
+    setMessages((prev) =>
+      prev.map((msg) => {
+        if (msg.id === messageId && msg.toolCalls) {
+          return {
+            ...msg,
+            toolCalls: msg.toolCalls.map((tc) => (tc.id === toolCall.id ? { ...tc, status: 'rejected' } : tc))
+          };
+        }
+        return msg;
+      })
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-slate-900 text-slate-200 font-sans selection:bg-primary-500/30">
+      <header className="bg-slate-900/80 backdrop-blur-md border-b border-slate-700 p-4 sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary-500 to-indigo-600 flex items-center justify-center shadow-lg shadow-primary-500/20">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19.428 15.428a2 2 0 00-1.022-.547l-2.384-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="font-bold text-lg text-white tracking-tight">Proactieve Assistent</h1>
+            <p className="text-xs text-slate-400">Analyse • Voorstel • Uitvoering</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-y-auto p-4 md:p-6">
+        <div className="max-w-4xl mx-auto pb-4">
+          {messages.map((msg) => (
+            <ChatMessage
+              key={msg.id}
+              message={msg}
+              onConfirmAction={(toolCall) => executeAction(toolCall, msg.id)}
+              onRejectAction={(toolCall) => rejectAction(toolCall, msg.id)}
+            />
+          ))}
+
+          {analysisState.isAnalyzing && (
+            <div className="flex items-center gap-3 text-slate-400 animate-pulse ml-2">
+              <div className="w-2 h-2 bg-primary-400 rounded-full animate-bounce" style={{ animationDelay: '0s' }}></div>
+              <div className="w-2 h-2 bg-primary-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
+              <div className="w-2 h-2 bg-primary-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+              <span className="text-sm font-medium">{analysisState.statusMessage}</span>
+            </div>
+          )}
+          <div ref={bottomRef} />
+        </div>
+      </main>
+
+      <InputArea onSend={handleSendMessage} disabled={analysisState.isAnalyzing} />
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Message, Sender, ToolCallData } from '../types';
+
+interface ChatMessageProps {
+  message: Message;
+  onConfirmAction: (toolCall: ToolCallData) => void;
+  onRejectAction: (toolCall: ToolCallData) => void;
+}
+
+const senderStyles: Record<Sender, string> = {
+  [Sender.USER]: 'bg-primary-500/10 border border-primary-500/30 self-end',
+  [Sender.ASSISTANT]: 'bg-slate-800/80 border border-slate-700',
+  [Sender.SYSTEM]: 'bg-amber-500/10 border border-amber-500/40'
+};
+
+const ChatMessage: React.FC<ChatMessageProps> = ({ message, onConfirmAction, onRejectAction }) => (
+  <div className="mb-3">
+    <div
+      className={`rounded-2xl px-4 py-3 text-sm text-slate-100 max-w-3xl shadow-md ${senderStyles[message.sender]}`}
+    >
+      <div className="flex items-start gap-2">
+        <div className="text-xs uppercase tracking-wider text-slate-400">
+          {message.sender === Sender.USER ? 'Jij' : message.sender === Sender.ASSISTANT ? 'Assistent' : 'Systeem'}
+        </div>
+        <div className="flex-1 space-y-2">
+          {message.text && <p className="whitespace-pre-wrap leading-relaxed">{message.text}</p>}
+          {message.systemNote && <p className="text-amber-300 text-xs">{message.systemNote}</p>}
+
+          {message.toolCalls && message.toolCalls.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs text-slate-300 flex items-center gap-2">
+                <span className="px-2 py-1 rounded-full bg-indigo-500/20 text-indigo-200 border border-indigo-500/40">
+                  Acties in afwachting
+                </span>
+                <span>Bevestig voor uitvoeren</span>
+              </div>
+              {message.toolCalls.map((tool) => (
+                <div
+                  key={tool.id}
+                  className="flex items-center justify-between bg-slate-900/60 border border-slate-700 rounded-lg px-3 py-2"
+                >
+                  <div>
+                    <p className="font-semibold text-sm text-white">{tool.name}</p>
+                    <p className="text-xs text-slate-400">{JSON.stringify(tool.args)}</p>
+                    {tool.status === 'executed' && tool.result && (
+                      <p className="text-xs text-emerald-300 mt-1">Resultaat: {tool.result}</p>
+                    )}
+                    {tool.status === 'rejected' && (
+                      <p className="text-xs text-amber-300 mt-1">Afgewezen, geen actie uitgevoerd.</p>
+                    )}
+                  </div>
+                  {tool.status === 'pending' && (
+                    <div className="flex gap-2">
+                      <button
+                        className="px-3 py-1 rounded-md bg-emerald-600 text-white text-xs"
+                        onClick={() => onConfirmAction(tool)}
+                      >
+                        Uitvoeren
+                      </button>
+                      <button
+                        className="px-3 py-1 rounded-md bg-slate-600 text-white text-xs"
+                        onClick={() => onRejectAction(tool)}
+                      >
+                        Annuleren
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default ChatMessage;

--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+
+interface InputAreaProps {
+  onSend: (text: string, image: string | null) => void;
+  disabled?: boolean;
+}
+
+const InputArea: React.FC<InputAreaProps> = ({ onSend, disabled }) => {
+  const [text, setText] = useState('');
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!text.trim() && !fileRef.current?.files?.length) return;
+
+    const file = fileRef.current?.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        onSend(text, reader.result as string);
+        setText('');
+        if (fileRef.current) fileRef.current.value = '';
+      };
+      reader.readAsDataURL(file);
+    } else {
+      onSend(text, null);
+      setText('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-slate-800/80 border-t border-slate-700 p-4">
+      <div className="max-w-4xl mx-auto flex items-end gap-3">
+        <textarea
+          className="flex-1 bg-slate-900 text-slate-50 rounded-xl p-3 focus:outline-none focus:ring-2 focus:ring-primary-500/60 border border-slate-700 resize-none"
+          rows={3}
+          placeholder="Beschrijf wat je wilt bereiken..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          disabled={disabled}
+        />
+        <div className="flex flex-col gap-2">
+          <input ref={fileRef} type="file" accept="image/*" className="text-xs text-slate-400" disabled={disabled} />
+          <button
+            type="submit"
+            disabled={disabled}
+            className="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Verstuur
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default InputArea;

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,0 +1,35 @@
+import { GeminiResponse, GeminiToolCall, ToolCallData } from '../types';
+
+// Mocked Gemini helpers for local development
+export const initializeChat = (): void => {
+  console.info('Chat initialized');
+};
+
+export const sendMessageToGemini = async (
+  text: string,
+  image?: string
+): Promise<GeminiResponse> => {
+  // Mock: echo text and propose a tool call to illustrate flow
+  const toolCalls: GeminiToolCall[] = text.toLowerCase().includes('agenda')
+    ? [
+        {
+          id: crypto.randomUUID(),
+          name: 'list_calendar_events',
+          args: { window: 'next_3_days' }
+        }
+      ]
+    : [];
+
+  return {
+    textResponse:
+      'Ik heb je bericht ontvangen en analyseer welke acties nuttig zijn. Wil je dat ik de voorgestelde stappen uitvoer?',
+    toolCalls: toolCalls.length ? toolCalls : undefined
+  };
+};
+
+export const sendToolResponseToGemini = async (
+  results: ToolCallData[]
+): Promise<string> => {
+  const executedNames = results.map((r) => r.name).join(', ');
+  return `Ik heb de resultaten verwerkt voor: ${executedNames}. Zal ik vervolgacties voorbereiden of iets toevoegen?`;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,42 @@
+export enum Sender {
+  USER = 'user',
+  ASSISTANT = 'assistant',
+  SYSTEM = 'system'
+}
+
+export type ToolStatus = 'pending' | 'executed' | 'rejected';
+
+export interface ToolCallData {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  status?: ToolStatus;
+  result?: string;
+  userConfirmationRequired?: boolean;
+}
+
+export interface Message {
+  id: string;
+  sender: Sender;
+  text?: string;
+  image?: string;
+  toolCalls?: ToolCallData[];
+  timestamp: number;
+  systemNote?: string;
+}
+
+export interface AnalysisState {
+  isAnalyzing: boolean;
+  statusMessage: string;
+}
+
+export interface GeminiToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface GeminiResponse {
+  textResponse: string;
+  toolCalls?: GeminiToolCall[];
+}


### PR DESCRIPTION
## Summary
- add a proactive assistant UI scaffold with stable IDs, tool metadata, and confirmation flows
- surface auto-executed tool steps and clearer error/system notes in the chat stream
- improve mock Gemini services and chat components for pending-action visibility

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694066faf29c832aa01d6752e257b761)